### PR TITLE
Removes deprecated unglue method and replaces with unclip

### DIFF
--- a/src/ngClip.js
+++ b/src/ngClip.js
@@ -44,7 +44,7 @@ angular.module('ngClipboard', []).
 
           scope.$on('$destroy', function() {
             client.off('mousedown', onMousedown);
-            client.unglue(element);
+            client.unclip(element);
           });
         });
       }


### PR DESCRIPTION
Zeroclipboard.js has deprecated the unglue method starting in 1.3.2.

https://github.com/zeroclipboard/zeroclipboard/commit/8159d5ae0952e75ed05bc46203561ed5bc7099a7
