### PR TITLE
Fix required angular version

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -3,7 +3,7 @@
   "version": "0.1.1",
   "main": "dest/ng-clip.min.js",
   "dependencies": {
-    "angular": "~1.0.4",
+    "angular": ">=1.0.4",
     "zeroclipboard": "~1.3.2"
   },
   "devDependencies": {}


### PR DESCRIPTION
I've successfully tested this lib with latest angular, it works well!

But I have some issues with bower, because it resolves your dependency as angular version `1.0.8` and can't install this package with latest angular.

This change tells bower, that package compatible with any version more than this and package can be installed with latest angular without additional confirmations
