### PR TITLE
Remove unused $window and $document

### DIFF
--- a/src/ngClip.js
+++ b/src/ngClip.js
@@ -17,7 +17,7 @@ angular.module('ngClipboard', []).
       }
     };
   }).
-  run(['$document', 'ngClip', function($document, ngClip) {
+  run(['ngClip', function(ngClip) {
     ZeroClipboard.config({
       moviePath: ngClip.path,
       trustedDomains: ["*"],
@@ -25,7 +25,7 @@ angular.module('ngClipboard', []).
       forceHandCursor: true
     });
   }]).
-  directive('clipCopy', ['$window', 'ngClip', function ($window, ngClip) {
+  directive('clipCopy', ['ngClip', function (ngClip) {
     return {
       scope: {
         clipCopy: '&',


### PR DESCRIPTION
in `.run()` and `.directive()`, both `$window` and `$document` were being injected, but not used.
