### PR TITLE
Update bower.json's main to conform to Bower's spec. #57

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "ng-clip",
   "version": "0.2.5",
-  "main": "dest/ng-clip.min.js",
+  "main": "src/ngClip.js",
   "dependencies": {
     "angular": ">=1.0.4",
     "zeroclipboard": "~2.1.0"


### PR DESCRIPTION
Fixes #57 
- Update `bower.json`'s main to conform to Bower's spec. Per https://github.com/bower/bower.json-spec, "main" should "not include minified files."
- Replace `ng-clip.js` symlink with actual file. Necessary in order for `ng-clip.js` to come down when fetched via Bower.
